### PR TITLE
Perbaikan Konfigurasi Cloudflare Workers untuk Deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,8 +1,8 @@
 name = "maskom"
-main = ".vercel/output/static/_worker.js"
+main = "dist/_worker.js"
 compatibility_date = "2024-09-19"
 compatibility_flags = ["nodejs_compat"]
 
 [assets]
-directory = ".vercel/output/static"
+directory = "dist"
 bypass_cache = false


### PR DESCRIPTION
Perbaikan ini menyelesaikan issue #16 terkait error deployment ke Cloudflare Workers.

Masalah utama adalah file entry-point untuk worker tidak ditemukan di lokasi yang diharapkan oleh Wrangler. Perubahan yang dilakukan:

1. Memperbarui konfigurasi di `wrangler.toml` untuk menyesuaikan path entry-point
2. Menyesuaikan struktur direktori output setelah build
3. Memastikan kompatibilitas konfigurasi dengan `@cloudflare/next-on-pages`

Setelah perubahan ini, proses deployment ke Cloudflare Workers seharusnya berjalan lancar.