### PR TITLE
docs: overhaul repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,68 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
-
-## Getting Started
-
-First, run the development server:
-
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Cloudflare Workers
-
-This project is configured to deploy to Cloudflare Workers using [`@cloudflare/next-on-pages`](https://github.com/cloudflare/next-on-pages).
-
-1. Build the worker-compatible bundle:
-
-   ```bash
-   npm run cf:build
-   ```
-
-   This generates the Worker entry point at `.vercel/output/static/_worker.js` and the static asset bundle used during deploy.
-
-2. Deploy the Worker with Wrangler:
-
-   ```bash
-   npm run cf:deploy
-   ```
-
-   The command bundles the latest build output and publishes it using the settings defined in `wrangler.toml`.
-
-Refer to [Cloudflare's deployment guide](https://developers.cloudflare.com/workers/wrangler/get-started/) for additional options such as environment-specific deploys.
-
 # Maskom
 
-## Live Website
+Maskom adalah situs pemasaran untuk layanan konektivitas dan managed service Maskom Network yang dibangun di atas Next.js App Router. Seluruh halaman utama ditulis dalam bahasa Indonesia dan memanfaatkan data statis TypeScript sehingga konten dapat diperbarui terpusat tanpa menyentuh komponen presentasi.
 
-The Maskom Network website is deployed and accessible at: [https://maskom.sulhi-cmz.workers.dev](https://maskom.sulhi-cmz.workers.dev)
+## Fitur Utama
+- **Runtime edge** dengan `export const runtime = 'edge'` sehingga build Next.js dapat dijalankan di Cloudflare Workers. 【F:src/app/layout.tsx†L1-L33】
+- **Layout reusable** melalui `Wrapper` yang menambahkan `ScrollToTop` dan `ToastContainer` agar interaksi global tetap konsisten. 【F:src/layouts/Wrapper.tsx†L1-L15】
+- **Navigasi data-driven** dari `src/data/MenuData.ts` sehingga struktur menu dapat dimodifikasi tanpa perubahan komponen. 【F:src/data/MenuData.ts†L1-L38】
+- **Section berbasiskan data** (mis. proses kerja, paket harga, testimoni) yang dibaca dari berkas `src/data/*.ts`. 【F:src/components/homes/home-one/Process.tsx†L1-L37】【F:src/components/homes/home-one/Price.tsx†L1-L68】
+- **Integrasi pihak ketiga** untuk animasi (Swiper, Isotope), pengiriman email (EmailJS), serta notifikasi (React Toastify). 【F:src/components/homes/home-two/Gallery.tsx†L1-L69】【F:src/components/forms/ContactForm.tsx†L1-L58】
+
+## Struktur Proyek
+```
+src/
+├── app/                # Route Next.js (App Router) termasuk halaman turunan
+├── components/         # Komponen per kategori (homes, pages, common, forms, dll.)
+├── data/               # Sumber data statis TypeScript
+├── hooks/              # Custom hook (mis. UseSticky)
+├── layouts/            # Header, footer, wrapper
+├── modals/             # Komponen modal
+└── styles/             # Entry point SCSS yang mengimpor aset publik
+public/
+├── _headers            # Aturan caching & header keamanan untuk Cloudflare Workers
+└── assets/             # Gambar, font, vendor JS/SCSS
+```
+
+> Catatan: Path alias `@/*` menunjuk ke `./src/*` dan `@/assets/*` ke `./public/assets/*` sebagaimana didefinisikan di `tsconfig.json`. 【F:tsconfig.json†L4-L26】
+
+## Persiapan Lingkungan
+1. Pastikan menggunakan Node.js 20.x dan npm 10.x (sesuai pipeline proyek).
+2. Instal dependensi: `npm install`
+3. Salin `.env.example` (jika tersedia) ke `.env.local` dan isi kredensial EmailJS produksi (`EMAILJS_SERVICE_ID`, `EMAILJS_TEMPLATE_ID`, `EMAILJS_PUBLIC_KEY`). Kredensial sementara saat ini masih ditulis langsung di `ContactForm`. 【F:src/components/forms/ContactForm.tsx†L1-L45】
+4. Untuk pratinjau Cloudflare, instal Wrangler (`npm install -g wrangler`) bila belum tersedia.
+
+## Perintah Pengembangan
+| Perintah | Fungsi |
+| --- | --- |
+| `npm run dev` | Menjalankan server Next.js di `http://localhost:3000` |
+| `npm run build` | Build produksi Next.js |
+| `npm run start` | Menjalankan hasil build secara lokal |
+| `npm run lint` | Menjalankan ESLint konfigurasi Next.js |
+| `npx tsc --noEmit` | Memeriksa tipe TypeScript tanpa menghasilkan berkas |
+| `npm run analyze` | Menjalankan `@next/bundle-analyzer` (memerlukan variabel `ANALYZE=true`) |
+| `npm run preview` | Build menggunakan OpenNext dan menjalankan pratinjau Workers |
+| `npm run deploy` | Build OpenNext dan deploy ke Cloudflare Workers |
+
+## Panduan Konten & Data
+- Komponen rumah utama (`HomeOne`) memuat header, hero, benefit, proses, paket harga, testimoni, FAQ, hingga CTA dalam urutan yang sama dengan landing page produksi. 【F:src/components/homes/home-one/index.tsx†L1-L32】
+- Data proses, paket harga, dan konten lain diseleksi dengan filter `page` sehingga dapat digunakan ulang di halaman lain (mis. halaman pricing). 【F:src/components/homes/home-one/Process.tsx†L17-L31】【F:src/data/PriceData.ts†L1-L112】
+- Komponen `Gallery` menggunakan Isotope untuk filter kategori dan membutuhkan DOM karena dipasang di sisi klien. Pastikan `window` tersedia sebelum inisialisasi. 【F:src/components/homes/home-two/Gallery.tsx†L1-L61】
+- Navigasi sticky dan tombol kembali ke atas memanfaatkan hook `UseSticky` untuk mendeteksi scroll >200px. 【F:src/hooks/UseSticky.ts†L1-L28】【F:src/components/common/ScrollToTop.tsx†L1-L32】
+
+## Styling & Aset
+- Entry SCSS berada di `src/styles/index.scss` dan mengimpor Bootstrap, font, animasi WOW, serta `public/assets/scss/style.scss`. 【F:src/styles/index.scss†L1-L10】
+- Aset gambar berada di `public/assets/images/*` dan diimpor melalui alias `@/assets/...` agar konsisten dengan konfigurasi Next.js. 【F:src/components/homes/home-one/Hero.tsx†L1-L16】
+- Header HTTP untuk caching, keamanan, dan CORS disetel melalui `public/_headers`. Sesuaikan origin CORS bila menjalankan di domain berbeda. 【F:public/_headers†L1-L27】
+
+## Deployment ke Cloudflare Workers
+1. Jalankan `npm run preview` untuk menghasilkan output OpenNext pada `.open-next/` dan memulai `wrangler dev` (membutuhkan login Wrangler).
+2. Gunakan `npm run deploy` untuk build dan deploy. Konfigurasi worker ada pada `wrangler.toml` dengan binding aset `ASSETS`. 【F:wrangler.toml†L1-L9】
+3. `open-next.config.ts` menggunakan konfigurasi default `defineCloudflareConfig()`. Sesuaikan bila membutuhkan binding tambahan. 【F:open-next.config.ts†L1-L3】
+
+## Dokumentasi Tambahan
+- [docs/ADR-0001-worker-stack.md](docs/ADR-0001-worker-stack.md) — keputusan arsitektur worker & Next.js
+- [doc/PERFORMANCE_OPTIMIZATION.md](doc/PERFORMANCE_OPTIMIZATION.md) — strategi optimasi performa
+- [doc/KNOWN_ISSUES.md](doc/KNOWN_ISSUES.md) — daftar isu yang perlu ditindaklanjuti
+
+Silakan perbarui dokumentasi ini apabila ada perubahan arsitektur, dependensi, atau proses operasional baru.

--- a/doc/KNOWN_ISSUES.md
+++ b/doc/KNOWN_ISSUES.md
@@ -1,158 +1,33 @@
 # Masalah yang Diketahui (Known Issues)
 
-Dokumen ini mencatat masalah yang diketahui dalam proyek website Maskom beserta solusi atau workarounds yang tersedia.
+Dokumen ini mencatat isu aktual pada kode Maskom berikut rekomendasi penanganan.
 
-## 1. Masalah Routing
+## 1. Kredensial EmailJS Ditanam Langsung di Kode
+- **Detail**: `ContactForm` memanggil `emailjs.sendForm` dengan service, template, dan public key yang ditulis langsung dalam repository. 【F:src/components/forms/ContactForm.tsx†L1-L45】
+- **Dampak**: Menyulitkan rotasi kredensial dan menimbulkan risiko penyalahgunaan ketika repository bersifat publik.
+- **Aksi**: Pindahkan nilai ke variabel lingkungan (`process.env`) dan muat dari konfigurasi runtime Cloudflare (`wrangler secret put`).
 
-### 1.1. Rute 404 yang Tidak Konsisten
-**Deskripsi**: Sebelumnya ada ketidaksesuaian penamaan direktori rute 404 (`[...not-faound]` daripada `[...not-found]`).
-**Status**: ✅ **Telah Diperbaiki**
-**Solusi**: Direktori telah diubah nama menjadi `[...not-found]` dan semua referensi telah diperbarui.
+## 2. Header CORS Mengunci ke Domain Produksi
+- **Detail**: `public/_headers` membatasi `Access-Control-Allow-Origin` hanya ke `https://maskom.co.id`. 【F:public/_headers†L11-L21】
+- **Dampak**: Permintaan lintas origin (mis. staging, preview Workers) akan ditolak browser.
+- **Aksi**: Tambahkan daftar origin yang valid atau gunakan wildcard terkontrol saat pengujian.
 
-### 1.2. Route Parameter Encoding
-**Deskripsi**: Beberapa route parameter mungkin tidak di-encode dengan benar saat mengandung karakter khusus.
-**Status**: ⚠️ **Dalam Pengawasan**
-**Workaround**: Gunakan `encodeURIComponent` saat mengirim parameter yang mengandung karakter khusus.
+## 3. Animasi WOW Tidak Terinisialisasi
+- **Detail**: Banyak komponen menggunakan kelas `wow fadeIn*` (contoh pada hero landing page), tetapi tidak ada inisialisasi `new WOW().init()` di kode React. 【F:src/components/homes/home-one/Hero.tsx†L13-L26】
+- **Dampak**: Animasi scroll tidak berjalan walaupun stylesheet `animate.css` sudah diimpor melalui `src/styles/index.scss`. 【F:src/styles/index.scss†L1-L10】
+- **Aksi**: Tambahkan inisialisasi WOW pada efek klien (mis. di `Wrapper` atau komponen khusus) atau ganti kelas `wow` dengan animasi CSS lain.
 
-## 2. Masalah Keamanan
+## 4. Metadata & Konten Halaman Turunan Masih Template
+- **Detail**: Beberapa halaman masih memakai judul dan deskripsi bawaan template AIcraft. Contoh: `app/home-two/page.tsx` dan `app/[...not-found]/page.tsx`. 【F:src/app/home-two/page.tsx†L1-L13】【F:src/app/[...not-found]/page.tsx†L1-L15】
+- **Dampak**: Branding tidak konsisten dan SEO tidak akurat ketika halaman diindeks.
+- **Aksi**: Lokalisasi metadata & isi setiap halaman sebelum publikasi.
 
-### 2.1. Zone ID Cloudflare
-**Deskripsi**: File `wrangler.toml` menggunakan placeholder untuk zone ID Cloudflare.
-**Status**: ⚠️ **Perlu Konfigurasi**
-**Solusi**: Ganti placeholder dengan zone ID yang sebenarnya dari dashboard Cloudflare.
+## 5. Komponen Offcanvas Lama Tidak Sinkron dengan Navigasi
+- **Detail**: `src/layouts/headers/Menu/Offcanvas.tsx` masih berisi daftar menu template (Project, Help Desk, dll.) dan tidak terhubung dengan `MenuData`. 【F:src/layouts/headers/Menu/Offcanvas.tsx†L1-L74】
+- **Dampak**: Potensi kebingungan bila komponen someday diaktifkan kembali atau tersisa di bundle.
+- **Aksi**: Sinkronkan isi menu dengan `MenuData` atau hapus komponen bila tidak digunakan.
 
-### 2.2. Environment Variables
-**Deskripsi**: Beberapa environment variables sensitif menggunakan nilai placeholder.
-**Status**: ⚠️ **Perlu Konfigurasi**
-**Solusi**: Perbarui `.env.local` dengan nilai yang sebenarnya untuk variabel seperti:
-- `EMAILJS_SERVICE_ID`
-- `EMAILJS_TEMPLATE_ID`
-- `EMAILJS_PUBLIC_KEY`
-- `CF_ACCOUNT_ID`
-- `CF_API_TOKEN`
-- `GITHUB_TOKEN`
-- `MCP_BASE_URL`
-- `MCP_API_TOKEN`
-
-## 3. Masalah Performa
-
-### 3.1. Bundle Size
-**Deskripsi**: Ukuran bundle JavaScript mungkin terlalu besar untuk halaman tertentu.
-**Status**: ⚠️ **Dalam Optimasi**
-**Solusi**: 
-- Gunakan dynamic imports untuk komponen besar
-- Hapus dependensi yang tidak digunakan
-- Terapkan code splitting yang lebih agresif
-
-### 3.2. Image Optimization
-**Deskripsi**: Beberapa gambar belum dioptimalkan sepenuhnya.
-**Status**: ⚠️ **Dalam Proses**
-**Solusi**: 
-- Gunakan format WebP ketika didukung
-- Terapkan lazy loading untuk semua gambar
-- Gunakan ukuran yang sesuai untuk setiap breakpoint
-
-## 4. Masalah Kompatibilitas
-
-### 4.1. Browser Lawas
-**Deskripsi**: Website mungkin tidak berfungsi dengan baik di browser lawas.
-**Status**: ⚠️ **Dalam Pengujian**
-**Solusi**: 
-- Tambahkan polyfill untuk fitur JavaScript modern
-- Gunakan autoprefixer untuk CSS
-- Pertimbangkan menggunakan Babel untuk transpilasi
-
-### 4.2. Device Responsiveness
-**Deskripsi**: Beberapa komponen mungkin tidak tampil dengan baik di ukuran layar tertentu.
-**Status**: ⚠️ **Dalam Perbaikan**
-**Solusi**: 
-- Periksa dan perbaiki breakpoint responsif
-- Uji di berbagai ukuran layar dan device
-- Gunakan unit yang fleksibel (rem, em, %)
-
-## 5. Masalah Integrasi
-
-### 5.1. EmailJS
-**Deskripsi**: Form kontak menggunakan placeholder untuk konfigurasi EmailJS.
-**Status**: ⚠️ **Perlu Konfigurasi**
-**Solusi**: Perbarui konfigurasi EmailJS di `.env.local` dengan nilai yang sebenarnya.
-
-### 5.2. Cloudflare Workers
-**Deskripsi**: Konfigurasi Cloudflare Workers menggunakan placeholder untuk beberapa nilai.
-**Status**: ⚠️ **Perlu Konfigurasi**
-**Solusi**: 
-- Perbarui zone ID dengan nilai yang sebenarnya
-- Konfigurasikan KV namespace dengan benar
-- Verifikasi konfigurasi R2 buckets
-
-## 6. Masalah Data
-
-### 6.1. Data Statis
-**Deskripsi**: Beberapa data masih menggunakan data statis daripada API.
-**Status**: ⚠️ **Dalam Pengembangan**
-**Solusi**: 
-- Integrasi dengan API backend
-- Implementasikan data fetching dengan SWR atau React Query
-- Tambahkan fallback untuk data statis
-
-### 6.2. Caching Data
-**Deskripsi**: Strategi caching data belum dioptimalkan.
-**Status**: ⚠️ **Dalam Pengembangan**
-**Solusi**: 
-- Implementasikan caching dengan Redis atau SWR
-- Tambahkan revalidation strategy
-- Gunakan incremental static regeneration (ISR)
-
-## 7. Masalah Deployment
-
-### 7.1. Build Time
-**Deskripsi**: Waktu build mungkin terlalu lama untuk proyek besar.
-**Status**: ⚠️ **Dalam Optimasi**
-**Solusi**: 
-- Gunakan incremental build
-- Optimalkan webpack configuration
-- Pertimbangkan menggunakan build cache
-
-### 7.2. CI/CD Pipeline
-**Deskripsi**: Pipeline CI/CD belum sepenuhnya otomatis.
-**Status**: ⚠️ **Dalam Pengembangan**
-**Solusi**: 
-- Implementasikan automated testing
-- Tambahkan linting dan formatting checks
-- Konfigurasikan deployment otomatis
-
-## 8. Masalah Dokumentasi
-
-### 8.1. Dokumentasi API
-**Deskripsi**: Dokumentasi API belum lengkap.
-**Status**: ⚠️ **Dalam Pengembangan**
-**Solusi**: 
-- Tambahkan dokumentasi API dengan Swagger/OpenAPI
-- Buat contoh penggunaan API
-- Sertakan informasi error handling
-
-### 8.2. Dokumentasi Komponen
-**Deskripsi**: Beberapa komponen tidak memiliki dokumentasi yang jelas.
-**Status**: ⚠️ **Dalam Pengembangan**
-**Solusi**: 
-- Tambahkan komentar dalam kode
-- Buat dokumentasi komponen terpisah
-- Sertakan contoh penggunaan
-
-## 9. Cara Melaporkan Masalah
-
-Jika Anda menemukan masalah baru, silakan:
-1. Periksa apakah masalah tersebut sudah terdaftar di sini
-2. Buat issue di repository dengan deskripsi yang jelas
-3. Sertakan langkah-langkah untuk mereproduksi masalah
-4. Tambahkan informasi lingkungan (browser, OS, versi)
-5. Lampirkan screenshot jika relevan
-
-## 10. Kontribusi
-
-Jika Anda ingin membantu memperbaiki masalah yang terdaftar:
-1. Fork repository
-2. Buat branch untuk perbaikan Anda
-3. Implementasikan solusi
-4. Tambahkan atau perbarui tes jika perlu
-5. Buat pull request dengan deskripsi yang jelas
+Jika Anda menemukan masalah baru:
+1. Verifikasi apakah sudah terdaftar pada dokumen ini.
+2. Laporkan melalui issue tracker dengan langkah reproduksi, informasi lingkungan, dan tangkapan layar bila perlu.
+3. Setelah perbaikan, perbarui status atau hapus entri yang sudah tidak relevan.

--- a/doc/PERFORMANCE_OPTIMIZATION.md
+++ b/doc/PERFORMANCE_OPTIMIZATION.md
@@ -1,168 +1,32 @@
 # Optimasi Performa
 
-Dokumen ini menjelaskan strategi dan implementasi optimasi performa untuk website Maskom.
+Dokumen ini merangkum praktik performa yang saat ini digunakan di Maskom serta rekomendasi tindak lanjut.
 
-## 1. Optimasi Gambar
+## 1. Manajemen Build & Analisis Bundle
+- Gunakan `npm run build` untuk memastikan semua halaman dapat diekspor di runtime edge. 【F:package.json†L7-L20】
+- Jalankan `npm run analyze` (set `ANALYZE=true`) untuk membuka laporan `@next/bundle-analyzer` dan mengidentifikasi modul besar. 【F:package.json†L7-L20】
+- Untuk pratinjau Workers gunakan `npm run preview` yang menjalankan OpenNext dan Wrangler dalam satu perintah. 【F:package.json†L7-L20】
 
-### Next.js Image Component
-Kami menggunakan komponen `next/image` untuk semua gambar di website untuk memastikan:
-- Lazy loading otomatis
-- Optimasi ukuran gambar berdasarkan device
-- Format gambar modern (WebP) ketika didukung
+## 2. Optimasi Aset Statis
+- Seluruh gambar impor melalui `next/image`, memberikan resizing otomatis, lazy loading, dan format modern. Contoh pada komponen hero, pricing, dan tim. 【F:src/components/homes/home-one/Hero.tsx†L1-L27】【F:src/components/homes/home-one/Price.tsx†L1-L68】【F:src/components/pages/teams/team/TeamArea.tsx†L1-L53】
+- `public/_headers` menerapkan cache agresif (`max-age=31536000, immutable`) untuk `public/assets` serta header keamanan tambahan. 【F:public/_headers†L1-L27】
+- Pastikan setiap penambahan aset besar ditempatkan di `public/assets/images` dan gunakan format terkompresi (WebP/AVIF) sebelum commit.
 
-### Implementasi
-```jsx
-import Image from 'next/image';
+## 3. Styling & CSS
+- Entry SCSS `src/styles/index.scss` menggabungkan Bootstrap, animasi WOW, dan stylesheet kustom `public/assets/scss/style.scss`. 【F:src/styles/index.scss†L1-L10】
+- Gunakan utility Bootstrap yang sudah tersedia sebelum menambahkan kelas baru untuk meminimalkan CSS tambahan.
+- Pertimbangkan purge/treeshake CSS saat build produksi apabila ukuran bundle meningkat (dapat ditambahkan melalui PostCSS plugin).
 
-// Contoh penggunaan
-<Image
-  src="/assets/images/example.jpg"
-  alt="Deskripsi gambar"
-  width={800}
-  height={600}
-  layout="responsive"
-/>
-```
+## 4. Optimalisasi JavaScript di Klien
+- Komponen slideshow (`Swiper`) dan grid filter (`Isotope`) berjalan hanya di klien. Pastikan inisialisasi dibungkus di hook `useEffect` untuk menghindari mismatch SSR. 【F:src/components/homes/home-one/Brand.tsx†L1-L76】【F:src/components/homes/home-two/Gallery.tsx†L1-L69】
+- Jika performa menjadi isu, gunakan dynamic import (`next/dynamic`) untuk memuat komponen berat secara lazy.
+- Hook `UseSticky` hanya memeriksa scroll >200px; review kembali ketika menambahkan interaksi lain agar event listener tetap ringan. 【F:src/hooks/UseSticky.ts†L1-L28】
 
-## 2. Strategi Caching
+## 5. Form & Integrasi Pihak Ketiga
+- Form kontak menggunakan EmailJS di sisi klien. Respon sukses menampilkan toast melalui `ToastContainer` di `Wrapper`. 【F:src/components/forms/ContactForm.tsx†L1-L58】【F:src/layouts/Wrapper.tsx†L1-L15】
+- Pastikan kredensial dipindahkan ke environment agar tidak menghambat caching atau memicu error di runtime edge (lihat Known Issues).
 
-### File _headers
-Kami mengimplementasikan strategi caching yang optimal melalui file `_headers`:
-
-```
-# Caching untuk static assets
-/assets/*
-  Cache-Control: public, max-age=31536000, immutable
-
-# Caching untuk halaman
-/*.html
-  Cache-Control: public, max-age=0, must-revalidate
-
-# Caching untuk API
-/api/*
-  Cache-Control: no-cache, no-store, must-revalidate
-```
-
-## 3. Optimasi Bundle Size
-
-### Code Splitting
-Kami menggunakan fitur code splitting bawaan Next.js untuk membagi bundle menjadi chunk-chunk kecil yang dimuat sesuai kebutuhan.
-
-### Tree Shaking
-Kami memastikan hanya mengimpor komponen yang diperlukan dari library untuk mengurangi ukuran bundle.
-
-### Analisis Bundle
-Untuk menganalisis ukuran bundle, jalankan:
-```bash
-npm run build
-npm run analyze
-```
-
-## 4. Optimasi Cloudflare Workers
-
-### Routing yang Efisien
-Kami mengoptimalkan routing untuk Cloudflare Workers melalui konfigurasi di `wrangler.toml`:
-
-```toml
-# Routes untuk worker
-[[routes]]
-pattern = "maskom.co.id/api/*"
-zone_id = "xxxxxxxxxxxxxxxx" # Placeholder - isi dengan zone ID yang sebenarnya dari Cloudflare dashboard
-
-# Routes untuk static assets
-[[routes]]
-pattern = "maskom.co.id/assets/*"
-zone_id = "xxxxxxxxxxxxxxxxxxxxxxxx" # Placeholder - isi dengan zone ID yang sebenarnya dari Cloudflare dashboard
-```
-
-## 5. Optimasi CSS
-
-### SCSS Modular
-Kami menggunakan pendekatan SCSS modular untuk memastikan hanya CSS yang diperlukan yang dimuat untuk setiap halaman.
-
-### Purging CSS
-Kami menghapus CSS yang tidak digunakan dalam produksi untuk mengurangi ukuran file.
-
-## 6. Lazy Loading Komponen
-
-### Dynamic Imports
-Kami menggunakan dynamic imports untuk komponen yang tidak segera diperlukan:
-
-```jsx
-import dynamic from 'next/dynamic';
-
-const HeavyComponent = dynamic(() => import('../components/HeavyComponent'));
-```
-
-## 7. Preloading dan Prefetching
-
-### Link Preloading
-Kami menggunakan `next/link` dengan prefetch untuk memuat halaman yang kemungkinan akan dikunjungi pengguna:
-
-```jsx
-import Link from 'next/link';
-
-<Link href="/halaman-berikutnya" prefetch>
-  Halaman Berikutnya
-</Link>
-```
-
-## 8. Monitoring Performa
-
-### Web Vitals
-Kami memantau Core Web Vitals untuk memastikan pengalaman pengguna yang optimal:
-- Largest Contentful Paint (LCP)
-- First Input Delay (FID)
-- Cumulative Layout Shift (CLS)
-
-### Tools Monitoring
-- Google PageSpeed Insights
-- Lighthouse
-- Web.dev
-
-## 9. Best Practices
-
-1. **Minimalkan jumlah request HTTP**
-2. **Gunakan CDN untuk static assets**
-3. **Optimalkan font loading**
-4. **Hindari layout shift**
-5. **Gunakan kompresi gzip/br**
-6. **Implementasikan service worker untuk caching offline**
-7. **Gunakan placeholder untuk gambar**
-8. **Hindari inline CSS yang besar**
-
-## 10. Pengujian Performa
-
-### Local Testing
-```bash
-npm run build
-npm run start
-```
-
-Lalu gunakan Lighthouse untuk menguji performa di localhost.
-
-### Production Testing
-Gunakan tools online seperti:
-- PageSpeed Insights
-- GTmetrix
-- WebPageTest
-
-## 11. Troubleshooting
-
-### Bundle Size Terlalu Besar
-1. Gunakan `next-bundle-analyzer` untuk menganalisis bundle
-2. Hapus dependensi yang tidak digunakan
-3. Gunakan dynamic imports untuk komponen besar
-4. Optimalkan gambar
-
-### Loading Lambat
-1. Periksa strategi caching
-2. Optimalkan gambar
-3. Gunakan lazy loading
-4. Periksa jumlah request HTTP
-
-### Layout Shift
-1. Tentukan ukuran gambar dengan jelas
-2. Gunakan placeholder
-3. Hindari font yang berubah ukuran
-4. Gunakan CSS yang stabil
+## 6. Monitoring & Uji Performa
+- Jalankan `npm run start` setelah build dan gunakan Lighthouse atau PageSpeed Insights untuk mengevaluasi Core Web Vitals.
+- Cloudflare menyediakan analitik melalui dashboard Workers; aktifkan log untuk melihat cache hit dan error edge.
+- Tambahkan pengujian regresi visual/performa (mis. menggunakan Playwright + Lighthouse CI) ketika pipeline CI/CD sudah siap.


### PR DESCRIPTION
## Summary
- replace the default README with project-specific guidance covering architecture, data flow, and deployment to Cloudflare Workers
- update ADR-0001 to capture the decision to keep the Next.js App Router stack and deploy via OpenNext
- refresh Known Issues and performance notes to document current risks (EmailJS keys, CORS headers, WOW.js setup) and recommended follow-ups

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd2f615dcc832dac1d00776349355a