### PR TITLE
fix: disable edge runtime on not-found page

### DIFF
--- a/src/app/[...not-found]/page.tsx
+++ b/src/app/[...not-found]/page.tsx
@@ -1,6 +1,8 @@
 import Wrapper from "@/layouts/Wrapper";
 import NotFound from "@/components/pages/error";
 
+export const runtime = 'nodejs';
+
 export const metadata = {
   title: "404 Not Found - AIcraft - AI Application & Generator React Next js Template",
 };


### PR DESCRIPTION
## Summary
- disable edge runtime for the catch-all not-found page so OpenNext builds

## Testing
- npx opennextjs-cloudflare build (fails locally: requires Node >=20)