### PR TITLE
Fix home-one-dark page component definition

### DIFF
--- a/src/app/home-one-dark/page.tsx
+++ b/src/app/home-one-dark/page.tsx
@@ -6,12 +6,12 @@ export const runtime = 'nodejs';
 export const metadata = {
   title: "Home One Dark AIcraft - AI Application & Generator React Next js Template",
 };
-const page = => {
+const Page = () => {
   return (
     <Wrapper>
       <HomeOneDark />
     </Wrapper>
-  )
-}
+  );
+};
 
-export default page
+export default Page;


### PR DESCRIPTION
## Summary
- fix the home page file syntax so Next.js can compile
- restore the default export to a capitalized component name