### PR TITLE
Make asset prefix configurable via environment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,8 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
+const assetPrefix = process.env.NEXT_PUBLIC_ASSET_PREFIX?.replace(/\/$/, "");
+
 const nextConfig: NextConfig = {
   // Konfigurasi untuk Cloudflare Pages
   output: 'standalone',
@@ -52,7 +54,7 @@ const nextConfig: NextConfig = {
   },
   
   // Konfigurasi untuk asset prefixes
-  assetPrefix: process.env.NODE_ENV === 'production' ? 'https://maskom.co.id' : undefined,
+  assetPrefix: assetPrefix || undefined,
   
   // Implementasi caching strategies untuk static assets
   async headers() {


### PR DESCRIPTION
## Summary
- compute the Next.js asset prefix from NEXT_PUBLIC_ASSET_PREFIX so previews use relative URLs
- keep production absolute prefix optional by trimming any trailing slash

## Testing
- npm run lint
- npx tsc --noEmit
- npm run build
- npm test