### PR TITLE
Remove assetPrefix to fix staging asset URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,8 +5,6 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
-const assetPrefix = process.env.NEXT_PUBLIC_ASSET_PREFIX?.replace(/\/$/, "");
-
 const nextConfig: NextConfig = {
   // Konfigurasi untuk Cloudflare Pages
   output: 'standalone',
@@ -52,9 +50,6 @@ const nextConfig: NextConfig = {
     // Menonaktifkan optimizeCss karena Cloudflare menangani ini
     optimizeCss: false,
   },
-  
-  // Konfigurasi untuk asset prefixes
-  assetPrefix: assetPrefix || undefined,
   
   // Implementasi caching strategies untuk static assets
   async headers() {


### PR DESCRIPTION
## Summary
- drop the Next.js assetPrefix override so all deployments serve assets relative to their own host

## Testing
- npm run lint
- npx tsc --noEmit
- npm run build
- npm test